### PR TITLE
A handful of improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,35 @@ You can look at `emoji.txt` for the definitive list of supported emoji.
 Emojis can be combined with horizontal rulers and,
 depending on your system fonts, ANSI colors, too.
 
-Emoji has only be tested on Mac OS X Terminal.app, YMMV.
+Emoji has only be tested on Mac OS X Terminal.app and Gnome Terminal, YMMV.
+
+### Multiple File Support
+
+As your `REPLesent.txt` grows, you may find yourself needing to split slides into logical chunks for quick navigation.
+
+In order to use this mode, simply place all your individual slide files into a directory (in this example, we'll be using the directory name `"slides"`), all ending with the file extension `.replesent`.
+
+Then, initialize REPLesent with the additional parameter `source="slides"`, which will concatinate all files in ASCIIbetical order. Suggested practice is to name files with a leading sequence number, padding with zeros (01, 02, 03 ... 14, 15 ...)
+
+One caveat is that since this is strict file concatination, slide separators will not be added automatically, so please remember to end your files with `---` or `--`.
+
+### Vim Syntax Highlighting
+
+Included in this repository is a `vim` directory, which contains a vim plugin for editing REPLesent slides.
+
+This plugin depends on [derekwyatt/vim-scala](https://github.com/derekwyatt/vim-scala/) for Scala syntax highlighting.
+
+Simply copy the files into your `~/.vim` directory to get started, or use [Vundle](https://github.com/VundleVim/Vundle.vim) (or similar) like:
+
+    Plugin 'derekwyatt/vim-scala'
+    Plugin 'marconilanna/REPLesent', {'rtp': 'vim/'}
 
 Thanks
 ------
 
 * [Davis Z. Cabral](https://github.com/daviscabral) for implementing
 horizontal ruler support.
+* [Devon Stewart](https://github.com/blast-hardcheese/) for adding multi-file support, a vim plugin, and enhancing code block syntax highlighting support.
 
 > *I don't care if it is used, I just want it to be useful*
 

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -429,7 +429,7 @@ case class REPLesent(
       def apply(line: String): (Line, Option[String]) = {
         val l = Line("< " + (line /: regex) { case (line, (color, regex)) =>
           regex.replaceAllIn(line, m =>
-            s"\\\\$color$m\\\\s"
+            s"\\\\${color}${Regex.quoteReplacement(m.toString)}\\\\s"
           )
         })
 

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -411,7 +411,7 @@ case class REPLesent(
     }
 
     object CodeHandler extends LineHandler {
-      private val regex: Seq[(String, Regex)] = {
+      private val patterns: Seq[(String, Regex)] = {
         val number: Regex = {
           val hex = "(?:0[xX][0-9A-Fa-f]+)".r
           val decimal = "(?:[1-9][0-9]*|0)".r
@@ -453,13 +453,22 @@ case class REPLesent(
       def switch: LineHandler = LineHandler
 
       def apply(line: String): (Line, Option[String]) = {
-        val l = Line("< " + (regex.foldLeft(line) { case (line, (color, regex)) =>
-          regex.replaceAllIn(line, m =>
-            s"\\\\${color}${Regex.quoteReplacement(m.toString)}\\\\s"
-          )
-        }))
+        val (colors, regexes) = patterns.unzip
 
-        (l, Option(line))
+        // new Regex("(?:(a)|(b)|(c))") will produce
+        // m.subgroups List(null, "b", null) when applied on "b"
+        val regex = new Regex(s"(?:(${regexes.mkString(")|(")}))")
+
+        val formatted = regex.replaceAllIn(line, { m =>
+          val colorIdx = m.subgroups.indexWhere(_ != null)
+          colors.drop(colorIdx).take(1).headOption
+            .map({ color =>
+              s"\\\\${color}${Regex.quoteReplacement(m.toString)}\\\\s"
+            })
+            .getOrElse(line)
+        })
+
+        (Line("< " + formatted), Option(line))
       }
     }
 

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -387,17 +387,17 @@ case class REPLesent(
   }
 
   private def parse(lines: Iterator[String]): IndexedSeq[Slide] = {
-    sealed trait Parser {
-      def switch: Parser
+    sealed trait LineHandler {
+      def switch: LineHandler
       def apply(line: String): (Line, Option[String])
     }
 
-    object LineParser extends Parser {
-      def switch: Parser = CodeParser
+    object LineHandler extends LineHandler {
+      def switch: LineHandler = CodeHandler
       def apply(line: String): (Line, Option[String]) = (Line(line), None)
     }
 
-    object CodeParser extends Parser {
+    object CodeHandler extends LineHandler {
       private val regex: Seq[(String, Regex)] = {
         val number: Regex = {
           val hex = "(?:0[xX][0-9A-F]+)".r
@@ -424,7 +424,7 @@ case class REPLesent(
         )
       }
 
-      def switch: Parser = LineParser
+      def switch: LineHandler = LineHandler
 
       def apply(line: String): (Line, Option[String]) = {
         val l = Line("< " + (regex.foldLeft(line) { case (line, (color, regex)) =>
@@ -443,14 +443,14 @@ case class REPLesent(
     , deck: IndexedSeq[Slide] = IndexedSeq.empty
     , code: IndexedSeq[String] = IndexedSeq.empty
     , codeAcc: IndexedSeq[String] = IndexedSeq.empty
-    , parser: Parser = LineParser
+    , handler: LineHandler = LineHandler
     ) {
       import config.newline
 
-      def switchParser: Acc = copy(parser = parser.switch)
+      def switchHandler: Acc = copy(handler = handler.switch)
 
       def append(line: String): Acc = {
-        val (l, c) = parser(line)
+        val (l, c) = handler(line)
         copy(content = content :+ l, codeAcc = c.fold(codeAcc)(codeAcc :+ _))
       }
 
@@ -480,7 +480,7 @@ case class REPLesent(
       line match {
         case `slideSeparator` => acc.pushSlide
         case `buildSeparator` => acc.pushBuild
-        case `codeDelimiter` => acc.switchParser
+        case `codeDelimiter` => acc.switchHandler
         case _ => acc.append(line)
       }
     }.pushSlide

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -418,24 +418,24 @@ case class REPLesent(
           val long = s"(?:${decimal}[DFLdfl])".r
           val float = s"(?:${decimal}\\.${decimal}[DFdf])".r
           val eNotation = s"(?:(?:${decimal}|${float})[eE][+\\-]?[0-9]+)".r
-          s"""\b(?:${eNotation}|${hex}|${long}|${float}|${decimal})\b""".r
+          s"""\\b(?:${eNotation}|${hex}|${long}|${float}|${decimal})\\b""".r
         }
 
         val string: Regex = "(?:s?\"(?:\\\\\"|[^\"])*\")".r
         val reserved: Regex = (
-          """\b(?:null|contains|exists|filter|filterNot|find|flatMap|""" +
-          """flatten|fold|forall|foreach|getOrElse|map|orElse)\b"""
+          s"""\\b(?:null|contains|exists|filter|filterNot|find|flatMap|""" +
+          s"""flatten|fold|forall|foreach|getOrElse|map|orElse)\\b"""
         ).r
-        val special: Regex = """\b(?:true|false|this)\b""".r
+        val special: Regex = s"""\\b(?:true|false|this)\\b""".r
         val typeSig: Regex = (
-          """\b(?:(?<=(?::|=>)\s{0,10})[$_]*[A-Z][_$A-Z0-9]*[\w$]*)\b"""
+          s"""\\b(?:(?<=(?::|=>)\s{0,10})[$_]*[A-Z][_$A-Z0-9]*[\w$]*)\\b"""
         ).r
 
         val syntax: Regex = (
-          """\b(?:abstract|case|catch|class|def|do|else|extends|final|""" +
-          """finally|for|forSome|if|implicit|import|lazy|match|new|""" +
-          """object|override|package|private|protected|return|sealed|""" +
-          """super|throw|trait|try|type|val|var|while|with|yield)\b"""
+          s"""\\b(?:abstract|case|catch|class|def|do|else|extends|final|""" +
+          s"""finally|for|forSome|if|implicit|import|lazy|match|new|""" +
+          s"""object|override|package|private|protected|return|sealed|""" +
+          s"""super|throw|trait|try|type|val|var|while|with|yield)\\b"""
         ).r
 
         Seq[(String, Regex)](

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -16,11 +16,12 @@
 case class REPLesent(
   width: Int = 0
 , height: Int = 0
-, input: String = "REPLesent.txt"
+, source: String = "REPLesent.txt"
 , slideCounter: Boolean = false
 , slideTotal: Boolean = false
 , intp: scala.tools.nsc.interpreter.IMain = null
 ) {
+  import java.io.File
   import scala.util.matching.Regex
   import scala.util.{ Try, Success, Failure }
 
@@ -371,16 +372,28 @@ case class REPLesent(
 
   private val repl = Option(intp)
 
-  private var deck = Deck(parseFile(input))
+  private var deck = Deck(parseSource(source))
 
-  private def parseFile(file: String): IndexedSeq[Slide] = {
+  private def parseSource(path: String): IndexedSeq[Slide] = {
     Try {
-      val lines = io.Source.fromFile(file).getLines
+      val pathFile = new File(path)
+      val lines: Iterator[String] = (
+        if (pathFile.isDirectory) {
+          pathFile
+            .list
+            .sorted
+            .filter(_.endsWith(".replesent"))
+            .flatMap { name => io.Source.fromFile(new File(pathFile, name)).getLines }
+            .toIterator
+        } else {
+          io.Source.fromFile(path).getLines
+        }
+      )
       parse(lines)
     } match {
       case Failure(e) =>
         e.printStackTrace
-        Console.err.print(s"Sorry, could not parse file $file. Quick, say something funny before anyone notices!")
+        Console.err.print(s"Sorry, could not parse $path. Quick, say something funny before anyone notices!")
         IndexedSeq.empty
       case Success(value) => value
     }
@@ -531,7 +544,7 @@ case class REPLesent(
   }
   private def reloadDeck(): Unit = {
     val curSlide = deck.currentSlideNumber
-    deck = Deck(parseFile(input))
+    deck = Deck(parseSource(source))
     show(deck.jumpTo(curSlide))
   }
 

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -21,7 +21,7 @@ case class REPLesent(
 , slideTotal: Boolean = false
 , intp: scala.tools.nsc.interpreter.IMain = null
 ) {
-  import scala.util.Try
+  import scala.util.{ Try, Success, Failure }
 
   private case class Config(
     top: String = "*"
@@ -376,9 +376,12 @@ case class REPLesent(
     Try {
       val lines = io.Source.fromFile(file).getLines
       parse(lines)
-    } getOrElse {
-      Console.err.print(s"Sorry, could not parse file $file. Quick, say something funny before anyone notices!")
-      IndexedSeq.empty
+    } match {
+      case Failure(e) =>
+        e.printStackTrace
+        Console.err.print(s"Sorry, could not parse file $file. Quick, say something funny before anyone notices!")
+        IndexedSeq.empty
+      case Success(value) => value
     }
   }
 

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -244,8 +244,8 @@ case class REPLesent(
 
     private lazy val emojis: Map[String, String] = {
       Try {
-        val input = io.Source.fromFile("emoji.txt").getLines
-        input.map { l =>
+        val emoji = io.Source.fromFile("emoji.txt").getLines
+        emoji.map { l =>
           val a = l.split(' ')
           (a(1), a(0))
         }.toMap
@@ -374,15 +374,15 @@ case class REPLesent(
 
   private def parseFile(file: String): IndexedSeq[Slide] = {
     Try {
-      val input = io.Source.fromFile(file).getLines
-      parse(input)
+      val lines = io.Source.fromFile(file).getLines
+      parse(lines)
     } getOrElse {
       Console.err.print(s"Sorry, could not parse file $file. Quick, say something funny before anyone notices!")
       IndexedSeq.empty
     }
   }
 
-  private def parse(input: Iterator[String]): IndexedSeq[Slide] = {
+  private def parse(lines: Iterator[String]): IndexedSeq[Slide] = {
     sealed trait Parser {
       def switch: Parser
       def apply(line: String): (Line, Option[String])
@@ -466,7 +466,7 @@ case class REPLesent(
     val buildSeparator = "--"
     val codeDelimiter = "```"
 
-    val acc = (Acc() /: input) { (acc, line) =>
+    val acc = (Acc() /: lines) { (acc, line) =>
       line match {
         case `slideSeparator` => acc.pushSlide
         case `buildSeparator` => acc.pushBuild

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -427,11 +427,11 @@ case class REPLesent(
       def switch: Parser = LineParser
 
       def apply(line: String): (Line, Option[String]) = {
-        val l = Line("< " + (line /: regex) { case (line, (color, regex)) =>
+        val l = Line("< " + (regex.foldLeft(line) { case (line, (color, regex)) =>
           regex.replaceAllIn(line, m =>
             s"\\\\${color}${Regex.quoteReplacement(m.toString)}\\\\s"
           )
-        })
+        }))
 
         (l, Option(line))
       }
@@ -476,7 +476,7 @@ case class REPLesent(
     val buildSeparator = "--"
     val codeDelimiter = "```"
 
-    val acc = (Acc() /: lines) { (acc, line) =>
+    val acc = lines.foldLeft(Acc()) { (acc, line) =>
       line match {
         case `slideSeparator` => acc.pushSlide
         case `buildSeparator` => acc.pushBuild

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -21,6 +21,7 @@ case class REPLesent(
 , slideTotal: Boolean = false
 , intp: scala.tools.nsc.interpreter.IMain = null
 ) {
+  import scala.util.matching.Regex
   import scala.util.{ Try, Success, Failure }
 
   private case class Config(
@@ -397,30 +398,36 @@ case class REPLesent(
     }
 
     object CodeParser extends Parser {
-      private val regex = {
-        val wb = "\\b"
+      private val regex: Seq[(String, Regex)] = {
+        val number: Regex = {
+          val hex = "(?:0[xX][0-9A-F]+)".r
+          val decimal = "(?:[1-9][0-9]*|0)".r
+          val long = s"(?:${decimal}[DFL])".r
+          val float = s"(?:${decimal}\\.${decimal}[DF])".r
+          val eNotation = s"(?:(?:${decimal}|${float})[eE][+\\-]?[0-9]+)".r
+          s"(?:${eNotation}|${hex}|${long}|${float}|${decimal})".r
+        }
 
-        val colors = Seq("g", "*", "c", "b", "m")
-
-        Seq(
-          """(?:true|false|null|this)"""
-        , """[$_]*[A-Z][_$A-Z0-9]*[\w$]*"""
-        , """(?:contains|exists|filter|filterNot|find|flatMap|flatten|fold|""" +
-            """forall|foreach|getOrElse|map|orElse)"""
-        , """(?i)(?:(?:0(?:[0-7]+|X[0-9A-F]+))L?|(?:(?:0|[1-9][0-9]*)""" +
-            """(?:(?:\.[0-9]+)?(?:E[+\-]?[0-9]+)?F?|L?))|\\.[0-9]+(?:E[+\-]?[0-9]+)?F?)"""
-        , """(?:abstract|case|catch|class|def|do|else|extends|final|finally|for|""" +
-            """forSome|if|implicit|import|lazy|match|new|object|override|package|private|""" +
-            """protected|return|sealed|super|throw|trait|try|type|val|var|while|with|yield)"""
-        ) map { s =>
-          (wb + s + wb).r
-        } zip colors
+        Seq[(String, Regex)](
+          "r" -> "(?:s?\"(?:\\\\\"|[^\"])*\")".r
+        , "c" -> """\b(?:null)\b""".r
+        , "m" -> """\b(?:true|false|this)\b""".r
+        , "g" -> """\b(?:(?<=(?::|=>)\s{0,10})[$_]*[A-Z][_$A-Z0-9]*[\w$]*)\b""".r
+        , "c" -> ("""\b(?:contains|exists|filter|filterNot|find|flatMap|flatten|fold|""" +
+                 """forall|foreach|getOrElse|map|orElse)\b"""
+                 ).r
+        , "r" -> s"""\b(?i)${number}\b""".r
+        , "y" -> ("""\b(?:abstract|case|catch|class|def|do|else|extends|final|finally|for|""" +
+                 """forSome|if|implicit|import|lazy|match|new|object|override|package|private|""" +
+                 """protected|return|sealed|super|throw|trait|try|type|val|var|while|with|yield)\b"""
+                 ).r
+        )
       }
 
       def switch: Parser = LineParser
 
       def apply(line: String): (Line, Option[String]) = {
-        val l = Line("< " + (line /: regex) { case (line, (regex, color)) =>
+        val l = Line("< " + (line /: regex) { case (line, (color, regex)) =>
           regex.replaceAllIn(line, m =>
             s"\\\\$color$m\\\\s"
           )

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -413,27 +413,38 @@ case class REPLesent(
     object CodeHandler extends LineHandler {
       private val regex: Seq[(String, Regex)] = {
         val number: Regex = {
-          val hex = "(?:0[xX][0-9A-F]+)".r
+          val hex = "(?:0[xX][0-9A-Fa-f]+)".r
           val decimal = "(?:[1-9][0-9]*|0)".r
-          val long = s"(?:${decimal}[DFL])".r
-          val float = s"(?:${decimal}\\.${decimal}[DF])".r
+          val long = s"(?:${decimal}[DFLdfl])".r
+          val float = s"(?:${decimal}\\.${decimal}[DFdf])".r
           val eNotation = s"(?:(?:${decimal}|${float})[eE][+\\-]?[0-9]+)".r
-          s"(?:${eNotation}|${hex}|${long}|${float}|${decimal})".r
+          s"""\b(?:${eNotation}|${hex}|${long}|${float}|${decimal})\b""".r
         }
 
+        val string: Regex = "(?:s?\"(?:\\\\\"|[^\"])*\")".r
+        val reserved: Regex = (
+          """\b(?:null|contains|exists|filter|filterNot|find|flatMap|""" +
+          """flatten|fold|forall|foreach|getOrElse|map|orElse)\b"""
+        ).r
+        val special: Regex = """\b(?:true|false|this)\b""".r
+        val typeSig: Regex = (
+          """\b(?:(?<=(?::|=>)\s{0,10})[$_]*[A-Z][_$A-Z0-9]*[\w$]*)\b"""
+        ).r
+
+        val syntax: Regex = (
+          """\b(?:abstract|case|catch|class|def|do|else|extends|final|""" +
+          """finally|for|forSome|if|implicit|import|lazy|match|new|""" +
+          """object|override|package|private|protected|return|sealed|""" +
+          """super|throw|trait|try|type|val|var|while|with|yield)\b"""
+        ).r
+
         Seq[(String, Regex)](
-          "r" -> "(?:s?\"(?:\\\\\"|[^\"])*\")".r
-        , "c" -> """\b(?:null)\b""".r
-        , "m" -> """\b(?:true|false|this)\b""".r
-        , "g" -> """\b(?:(?<=(?::|=>)\s{0,10})[$_]*[A-Z][_$A-Z0-9]*[\w$]*)\b""".r
-        , "c" -> ("""\b(?:contains|exists|filter|filterNot|find|flatMap|flatten|fold|""" +
-                 """forall|foreach|getOrElse|map|orElse)\b"""
-                 ).r
-        , "r" -> s"""\b(?i)${number}\b""".r
-        , "y" -> ("""\b(?:abstract|case|catch|class|def|do|else|extends|final|finally|for|""" +
-                 """forSome|if|implicit|import|lazy|match|new|object|override|package|private|""" +
-                 """protected|return|sealed|super|throw|trait|try|type|val|var|while|with|yield)\b"""
-                 ).r
+          "r" -> string
+        , "c" -> reserved
+        , "m" -> special
+        , "g" -> typeSig
+        , "r" -> number
+        , "y" -> syntax
         )
       }
 

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -413,11 +413,11 @@ case class REPLesent(
     object CodeHandler extends LineHandler {
       private val patterns: Seq[(String, Regex)] = {
         val number: Regex = {
-          val hex = "(?:0[xX][0-9A-Fa-f]+)".r
-          val decimal = "(?:[1-9][0-9]*|0)".r
-          val long = s"(?:${decimal}[DFLdfl])".r
-          val float = s"(?:${decimal}\\.${decimal}[DFdf])".r
-          val eNotation = s"(?:(?:${decimal}|${float})[eE][+\\-]?[0-9]+)".r
+          val hex = "(?:0[xX][0-9A-Fa-f]+)"
+          val decimal = "(?:[1-9][0-9]*|0)"
+          val long = s"(?:${decimal}[DFLdfl])"
+          val float = s"(?:${decimal}\\.${decimal}[DFdf])"
+          val eNotation = s"(?:(?:${decimal}|${float})[eE][+\\-]?[0-9]+)"
           s"""\\b(?:${eNotation}|${hex}|${long}|${float}|${decimal})\\b""".r
         }
 

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -417,7 +417,7 @@ case class REPLesent(
           val decimal = "(?:[1-9][0-9]*|0)"
           val long = s"(?:${decimal}[DFLdfl])"
           val float = s"(?:${decimal}\\.${decimal}[DFdf])"
-          val eNotation = s"(?:(?:${decimal}|${float})[eE][+\\-]?[0-9]+)"
+          val eNotation = s"(?:${decimal}(?:\\.0?${decimal})?[eE][+\\-]?[0-9]+)"
           s"""\\b(?:${eNotation}|${hex}|${long}|${float}|${decimal})\\b""".r
         }
 

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -427,9 +427,11 @@ case class REPLesent(
           s"""flatten|fold|forall|foreach|getOrElse|map|orElse)\\b"""
         ).r
         val special: Regex = s"""\\b(?:true|false|this)\\b""".r
-        val typeSig: Regex = (
-          s"""\\b(?:(?<=(?::|=>)\s{0,10})[$_]*[A-Z][_$A-Z0-9]*[\w$]*)\\b"""
-        ).r
+        val typeSig: Regex = {
+          val token: String => String = { limit => s"[$$_]${limit}[A-Z][_$$A-Z0-9]${limit}[\\w$$]${limit}" }
+          val prefix: String = s"""(?<=(?::)\\s{0,10}|\\btype ${token("{0,10}")}\\s{0,10}=\\s{0,10})"""
+          s"""\\b(?:${prefix}(?:${token("*")}|\\s*=>\\s*|\\s*with\\s*)*)\\b"""
+        }.r
 
         val syntax: Regex = (
           s"""\\b(?:abstract|case|catch|class|def|do|else|extends|final|""" +

--- a/vim/ftdetect/replesent.vim
+++ b/vim/ftdetect/replesent.vim
@@ -1,0 +1,2 @@
+au BufRead,BufNewFile *.replesent set filetype=replesent
+au BufRead,BufNewFile REPLesent.txt set filetype=replesent

--- a/vim/syntax/replesent.vim
+++ b/vim/syntax/replesent.vim
@@ -1,0 +1,7 @@
+" Vim syntax file
+" Language: REPLesent
+" Latest Revision: 2016-05-17
+" Depends on: https://github.com/derekwyatt/vim-scala
+
+syntax include @Scala syntax/scala.vim
+syntax region replesentBlock start=/```/ end=/```/ contains=@Scala


### PR DESCRIPTION
I recently used REPLesent for a presentation at Lambdaconf 2016 -- It worked very well (almost no issues!) I'd like to contribute my modifications back, so here's a list of the changes included in this PR:
- Clarifying shadowed (and widely scoped) `input` values
- Print stack trace on parse failure
- Refactoring syntax highlighting regexes for minor clarity improvements and defining more colors
- Renaming `Parser`s to `Handler`s, hopefully in preparation for including a real parser some day
- Added a vim syntax highlighting file (depends on [derekwyatt/vim-scala](https://github.com/derekwyatt/vim-scala))
- Added multi-file support. Specifying a directory for `REPLesent(source=...)` will look for `*.replesent`, sort them ASCIIbetically, then read them all in sequence.
