### PR TITLE
Adding noexec and silent modifiers to code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Separator | Description
 `---` | Separates slides
 `--` | Separates builds
 <code>```</code> | Delineates Scala code
+<code>```noexec</code> | Starts a code block that will not be run, only displayed
+<code>```silent</code> | Starts a code block that will not be displayed, only run
 
 ### Text alignment
 

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -402,6 +402,7 @@ case class REPLesent(
 
   private def parse(lines: Iterator[String]): IndexedSeq[Slide] = {
     sealed trait Flags
+    case object NoExec extends Flags
 
     sealed trait LineHandler {
       def switch(flags: Seq[Flags]): LineHandler
@@ -471,7 +472,7 @@ case class REPLesent(
             .getOrElse(line)
         })
 
-        (Line("< " + formatted), Option(line))
+        (Line("< " + formatted), Option(line).filterNot(_ => flags.contains(NoExec)))
       }
     }
 
@@ -513,11 +514,13 @@ case class REPLesent(
     val slideSeparator = "---"
     val buildSeparator = "--"
     val codeDelimiter = "```"
+    val noexecCodeDelimiter = "```noexec"
 
     val acc = lines.foldLeft(Acc()) { (acc, line) =>
       line match {
         case `slideSeparator` => acc.pushSlide
         case `buildSeparator` => acc.pushBuild
+        case `noexecCodeDelimiter` => acc.switchHandler(NoExec)
         case `codeDelimiter` => acc.switchHandler()
         case _ => acc.append(line)
       }

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -345,10 +345,10 @@ case class REPLesent(
     def runCode: Unit = {
       val code = currentSlide.code(buildCursor)
 
-      if (repl.isEmpty) {
-        Console.err.print(s"No reference to REPL found. Please call with parameter intp=$$intp")
-      } else if (code.isEmpty) {
+      if (code.isEmpty) {
         Console.err.print("No code for you")
+      } else if (repl.isEmpty) {
+        Console.err.print(s"No reference to REPL found. Please call with parameter intp=$$intp")
       } else {
         repl foreach (_.interpret(code))
       }

--- a/REPLesent.scala
+++ b/REPLesent.scala
@@ -13,6 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+object REPLesent {
+  import scala.language.implicitConversions
+  trait Interpreter {
+    def interpret(code: String): Unit
+  }
+
+  object Interpreter {
+    object dummy extends Interpreter {
+      def interpret(code: String): Unit = Console.err.print(s"No reference to REPL found. Please call with parameter intp=$$intp")
+    }
+
+    implicit def apply(intp: scala.tools.nsc.interpreter.IMain): Interpreter = Option(intp).fold[Interpreter](dummy) { value =>
+      new Interpreter {
+        def interpret(code: String): Unit = {
+          val _ = intp.interpret(code)
+        }
+      }
+    }
+  }
+}
+
 case class REPLesent(
   width: Int = 0
 , height: Int = 0
@@ -20,7 +41,7 @@ case class REPLesent(
 , slideCounter: Boolean = false
 , slideTotal: Boolean = false
 , padNewline: Boolean = false
-, intp: scala.tools.nsc.interpreter.IMain = null
+, intp: REPLesent.Interpreter = REPLesent.Interpreter.dummy
 ) {
   import java.io.File
   import scala.util.matching.Regex

--- a/test/REPLesentSpec.scala
+++ b/test/REPLesentSpec.scala
@@ -1542,4 +1542,24 @@ class REPLesentSpec extends FreeSpec {
       assert(slide4.output contains "*  3/3  *")
     }
   }
+
+  "Execution control" - {
+    "noexec" in {
+      val replesent = REPLesent(3, 3, testFile("noexec"))
+
+      val slide1 = capture(replesent.first)
+      assert(slide1.output contains "Syntax error!")
+      val slide1run = capture(replesent.run)
+      assert(slide1run.error === "No code for you")
+    }
+
+    "silent" in {
+      val replesent = REPLesent(3, 3, testFile("silent"))
+
+      val slide1 = capture(replesent.first)
+      assert(slide1.output !== "object Foo")
+      val slide1run = capture(replesent.run)
+      assert(slide1run.error === "No reference to REPL found. Please call with parameter intp=$intp")
+    }
+  }
 }

--- a/test/resources/test_noexec.txt
+++ b/test/resources/test_noexec.txt
@@ -1,0 +1,3 @@
+```noexec
+Syntax error!
+```

--- a/test/resources/test_silent.txt
+++ b/test/resources/test_silent.txt
@@ -1,0 +1,3 @@
+```silent
+object Foo
+```


### PR DESCRIPTION
Looks like I never actually submitted these upstream, my apologies!

- Resolves #11 
- ~Moving `REPLesent` class into a `replesent` package~ Forgot why this was done, and it broke tests, so removed it
- ~`padNewLine` adds an empty newline after rendering a slide, then moves the cursor back up, so `n<Enter>` doesn't cause the slides to jump due to scrolling~ Split to #16 
- ~Resolving conflict against top-level `io` packages vs `scala.io`~ Split to #16 